### PR TITLE
fix: add missing aiofiles dependency for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ tqdm==4.66.1
 pyyaml==6.0.1
 click==8.1.7
 tenacity==8.2.3
+aiofiles==24.1.0
 
 # Development and Testing
 pytest==7.4.3


### PR DESCRIPTION
## Summary

This PR fixes a missing dependency that was causing test collection errors in the coverage bot workflow.

## Changes
- Add  to requirements.txt

## Why?
The coverage bot workflow was failing with:
```
ModuleNotFoundError: No module named 'aiofiles'
```

This dependency is needed by some test files but was missing from requirements.txt.

## Impact
After this fix, the coverage bot should be able to run tests without the aiofiles import error.

Note: There are still other test issues (numpy.typing and risk_management.models) that may need separate fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>