### PR TITLE
fix: add missing risk management models init file

### DIFF
--- a/src/risk_management/models/__init__.py
+++ b/src/risk_management/models/__init__.py
@@ -1,0 +1,27 @@
+"""Risk management models."""
+from typing import Dict, List, Any, Optional, Union, Tuple
+
+# Export all models
+from .api_throttler import BinanceAPIThrottler, RateLimitRule
+from .cost_model import CostModel, TradeCosts
+from .drawdown_guard import DrawdownGuard
+from .position_sizing import (
+    PositionSizer,
+    FixedFractionalPositionSizer,
+    KellyPositionSizer,
+    VolatilityBasedPositionSizer,
+    VolatilityParityPositionSizer
+)
+
+__all__ = [
+    'BinanceAPIThrottler',
+    'RateLimitRule',
+    'CostModel',
+    'TradeCosts',
+    'DrawdownGuard',
+    'PositionSizer',
+    'FixedFractionalPositionSizer',
+    'KellyPositionSizer',
+    'VolatilityBasedPositionSizer',
+    'VolatilityParityPositionSizer'
+]


### PR DESCRIPTION
## Summary

This PR adds the missing __init__.py file for src/risk_management/models that was accidentally excluded from the previous commit.

## Changes
- Add src/risk_management/models/__init__.py with all necessary exports

## Why?
The coverage bot was failing with:
```
ModuleNotFoundError: No module named 'src.risk_management.models'
```

This was because the models directory was in .gitignore and the __init__.py file wasn't tracked.

## Impact
This should fix the remaining test collection errors for risk management tests.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>