### PR TITLE
fix: correct VolatilityParityPositionSizer import name

### DIFF
--- a/src/risk_management/models/__init__.py
+++ b/src/risk_management/models/__init__.py
@@ -9,7 +9,6 @@ from .position_sizing import (
     PositionSizer,
     FixedFractionalPositionSizer,
     KellyPositionSizer,
-    VolatilityBasedPositionSizer,
     VolatilityParityPositionSizer
 )
 
@@ -22,6 +21,5 @@ __all__ = [
     'PositionSizer',
     'FixedFractionalPositionSizer',
     'KellyPositionSizer',
-    'VolatilityBasedPositionSizer',
     'VolatilityParityPositionSizer'
 ]


### PR DESCRIPTION
## Description
Fixed incorrect import name causing test collection errors.

## Problem
The __init__.py file was trying to import  but the actual class name in position_sizing.py is .

## Solution
- Updated imports in __init__.py to use the correct class name
- Removed the non-existent VolatilityBasedPositionSizer from __all__

## Test Impact
This should fix the ImportError in test_api_throttler.py and allow all tests to collect properly.