### PR TITLE
🔧 Fix: Upgrade deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -82,7 +82,7 @@ jobs:
         fi
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
@@ -104,7 +104,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -139,7 +139,7 @@ jobs:
         fi
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
@@ -151,7 +151,7 @@ jobs:
         python scripts/update_ci_status.py || echo "Coverage report generation failed"
     
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-reports
         path: |

--- a/.github/workflows/coverage-bot.yml
+++ b/.github/workflows/coverage-bot.yml
@@ -65,7 +65,7 @@ jobs:
         fi
     
     - name: 📊 Cache test data
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: tests/_data
         key: gdrive-${{ hashFiles('scripts/fetch_gdrive_data.sh') }}-${{ secrets.GDRIVE_SHA256 }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,7 @@ jobs:
         bash scripts/fetch_gdrive_data.sh || echo "⚠️ Google Drive data fetch failed"
     
     - name: 📊 Cache test data
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: tests/_data
         key: test-data-${{ hashFiles('scripts/fetch_gdrive_data.sh') }}-${{ secrets.GDRIVE_SHA256 }}
@@ -111,7 +111,7 @@ jobs:
     
     - name: 📤 Upload coverage to Codecov
       if: always()
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage-combined.xml,./coverage-e2e.xml,./coverage-heavy.xml,./coverage-integration.xml
         flags: e2e,heavy,integration
@@ -134,7 +134,7 @@ jobs:
     
     - name: 💾 Upload test artifacts
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: e2e-test-results
         path: |


### PR DESCRIPTION
## Description

This PR upgrades all deprecated GitHub Actions to their v4 versions to fix the workflow failures.

## Changes

- ✅ Upgrade  from v3 to v4
- ✅ Upgrade  from v3 to v4  
- ✅ Upgrade  from v3 to v4

## Why?

GitHub has deprecated v3 of these actions and workflows are automatically failing when using them. This upgrade ensures our CI/CD pipeline continues to work properly.

## Testing

- Workflow will be tested immediately after merge
- All actions now use the latest stable versions

Fixes the error: "This request has been automatically failed because it uses a deprecated version"